### PR TITLE
Remove NGINX dependency in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,3 @@ services:
         command: gunicorn api:create_app() --bind 0.0.0.0:8000
         ports:
             - 8000:8000
-    nginx:
-        build: ./nginx
-        ports:
-            - 80:80
-        depends_on:
-            - radio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     radio:
         build: .
         command: gunicorn api:create_app() --bind 0.0.0.0:8000
-        expose:
-            - 8000
+        ports:
+            - 8000:8000
     nginx:
         build: ./nginx
         ports:


### PR DESCRIPTION
fixes #13 

Remove the NGINX container from `docker-compose.yml`, and directly map gunicorn port 8000 to the host system